### PR TITLE
Buffer local swaplist

### DIFF
--- a/doc/swapit.txt
+++ b/doc/swapit.txt
@@ -170,7 +170,7 @@ Contents                                                     *swapit-contents*
 
         ~/.vim/after/ftplugin/{filetype}_swapit.vim
 
-        let g:swap_lists = [
+        let b:swap_lists = [
         \ {'name':'hello_world', 'options':
         \ ['Hello World!','GoodBye Cruel World!' , 'See You Next Tuesday!']},
         ...

--- a/plugin/swapit.vim
+++ b/plugin/swapit.vim
@@ -77,20 +77,6 @@
 "               with custom execs eg.
 "               exec "SwapList function_scope private protected public"
 "
-"               For this alpha version multi word swap list is a bit trickier
-"               to to define. You can add to the swap list directly using .
-"
-"                 call add(b:swap_lists, {'name':'Multi Word Example',
-"                             \'options': ['swap with spaces',
-"                             \'swap with  @#$@# chars in it' , \
-"                             \'running out of ideas here...']})
-"
-"               Future versions will make this cleaner
-"
-"               Also if you have a spur of the moment Idea type
-"               :SwapIdea
-"               To get to the current filetypes swapit file
-"
 "               4. Insert mode completion
 "
 "               You can use a swap list in insert mode by typing the list name


### PR DESCRIPTION
With only one global `g:swap_lists`, setting the swaplist for one filetype overrides the previous filetype's list. This breaks swapping with multiple filetypes in parallel (e.g. a PHP and CSS file); the last opened filetype "wins".

Instead, a buffer-local variable should be used. Each buffer has its own swaplist (according to its filetype / manual `:SwapList`) definition then.
