### PR TITLE
Allow command chaining for :ClearSwapList and :SwapIdea

### DIFF
--- a/plugin/swapit.vim
+++ b/plugin/swapit.vim
@@ -161,8 +161,8 @@ vnoremap <silent><c-x> :<c-u>let swap_count = v:count<Bar>call SwapWord(<SID>Get
 
 " For adding lists
 com! -nargs=* SwapList call AddSwapList(<q-args>)
-com! ClearSwapList let b:swap_lists = []
-com! SwapIdea call OpenSwapFileType()
+com! -bar ClearSwapList let b:swap_lists = []
+com! -bar SwapIdea call OpenSwapFileType()
 com! -range -nargs=1 SwapWordVisual call SwapWord(getline('.'), 1, <f-args>,'yes')
 "au BufEnter call LoadFileTypeSwapList()
 com! SwapListLoadFT call LoadFileTypeSwapList()


### PR DESCRIPTION
Especially for :ClearSwapList, one may want to put this into

```
let b:undo_ftplugin .= '|ClearSwapList'
```

To enable appending other such commands, the command must support chaining, and because it doesn't take arguments, this is trivially done through `-bar`.
