### PR TITLE
Add `drop` to SwapList git_rebase_i

### DIFF
--- a/after/ftplugin/gitrebase_swapit.vim
+++ b/after/ftplugin/gitrebase_swapit.vim
@@ -1,2 +1,2 @@
 ClearSwapList
-SwapList git_rebase_i pick reword edit squash fixup exec
+SwapList git_rebase_i pick reword edit squash fixup exec drop


### PR DESCRIPTION
I miss `drop` in the SwapList `git_rebase_i`. Is `drop` omitted on purpose?

see also https://github.com/tpope/vim-git/pull/34