### PR TITLE
Removing a superfluous space in swapit.vim

### DIFF
--- a/plugin/swapit.vim
+++ b/plugin/swapit.vim
@@ -476,7 +476,7 @@ else
                 \{'name':'ON/OFF', 'options': ['ON','OFF']},
                 \{'name':'comparison_operator', 'options': ['<','<=','==', '>=', '>' , '=~', '!=']},
                 \{'name':'boolean_operator', 'options': ['&&','||']},                
-                \{'name': 'datatype', 'options': ['bool', 'char','int','unsigned int', 'float','long', 'double']},
+                \{'name':'datatype', 'options': ['bool', 'char','int','unsigned int', 'float','long', 'double']},
                 \{'name':'weekday', 'options': ['Sunday','Monday', 'Tuesday', 'Wednesday','Thursday', 'Friday', 'Saturday']},
                 \]
 endif


### PR DESCRIPTION
This space messes up the syntax highlighting for this line (especially when compared with adjacent lines) whenever I open `swapit.vim` in Vim with the default color scheme.

Before:
![image](https://user-images.githubusercontent.com/7541582/99883967-afdb2780-2c3b-11eb-97ca-16baaecae006.png)

After:
![image](https://user-images.githubusercontent.com/7541582/99883982-c8e3d880-2c3b-11eb-9f65-00640fc7fa41.png)
